### PR TITLE
Make NN_DESCENT the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,16 @@ Set the correct path for Raft in `cuda/CMakeLists.txt` file. Then, proceed to ru
 
 ## Benchmarks
 
-Wikipedia (OpenAI, 1536 dimensions, 25k vectors):
+Wikipedia (768 dimensions, 1M vectors):
 
-|     | CuVS (RTX 4090) | Lucene HNSW (Ryzen 7950X) | Improvement |
-| -------- | ------- | ------------------------- | ------------- |
-| Indexing  | 5.2 seconds    | 26.5 seconds | 5.1x |
-| Searching | 1 millisecond     | 22 milliseconds | 22x |
+|                           | Indexing   | Improvement | Search | Improvement |
+| ------------------------- | ---------- | ----------- | ------ | ----------- |
+| CuVS (RTX 2080 Ti)        | 37.83 sec  |  **26x**    |  2 ms  |   **4x**    |
+| Lucene HNSW (Ryzen 7700X) | 992.37 sec |      -      |  8 ms  |      -      |
 
-Wikipedia (768 dimensions, 750k vectors):
-
-|     | CuVS (RTX 4090) | Lucene HNSW (Ryzen 7950X) | Improvement |
-| -------- | ------- | ------------------------- | ------- |
-| Indexing  | 167.9 seconds    | 804 seconds | 4.8x |
-
-
-> :warning: Switching over the index building algorithm from IVF_PQ to [NN_DESCENT](https://github.com/rapidsai/raft/pull/1748) will likely result in further 8x (or better) speed up. This is work in progress.
 
 ## Next steps
-* Instead of using the IVF_PQ build algorithm of Cagra, switch over to NN_DESCENT, for a further 8x (or better) improvement in indexing speed.
+
 * Instead of extending the IndexSearcher, create a [KnnVectorFormat](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/codecs/KnnVectorsFormat.java) and corresponding KnnVectorsWriter and KnnVectorsReader for tighter integration.
 
 ## Contributors

--- a/cuda/src/CudaIndexJni.cu
+++ b/cuda/src/CudaIndexJni.cu
@@ -50,8 +50,10 @@ JNIEXPORT jint JNICALL Java_com_searchscale_lucene_vectorsearch_jni_CuVSIndexJni
   raft::resource::sync_stream(dev_resources, stream);
   std::cout<<"Data copying time (CPU to GPU): "<<(ms()-startTime)<<std::endl;
 
+
   // Build the index
   startTime = ms();
+  index_params.build_algo = raft::neighbors::cagra::graph_build_algo::NN_DESCENT;
   auto ind = raft::neighbors::cagra::build<float, uint32_t>(dev_resources, index_params, raft::make_const_mdspan(dataset.view()));
   std::cout << "Cagra Index building time: " << (ms()-startTime) << std::endl;
 


### PR DESCRIPTION
This code change does the following:
- Sets `NN_DESCENT` as the default build algo for CAGRA, as the indexing performance of `NN_DESCENT` is significantly better than that of the default build algo `IVF_PQ`.
- Updates the benchmarks.

